### PR TITLE
Use Qt Resource System for icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,22 @@
 As this package is a subsidiarian of [MNE-Python](https://mne.tools/dev/index.html)
 its [guidelines](https://github.com/mne-tools/mne-python) for contributing apply as well.
 
+
 ## Setting up development environment
+
 Follow the [instructions from mne-python](https://mne.tools/dev/install/contributing.html#setting-up-your-local-development-environment)
 and additionally install the dependencies for this repository:
 
 ```
 pip install -e ".[tests]"
 ```
+
+## Modifying icons
+
+The icons are stored in the `icons` folder, which contains two themes "light" and "dark". If you want to modify an existing icon or add a new one, you will need to regenerate the resource file. This can be done by running the following command in the `mne_qt_browser` folder (this requires `PySide6` to be installed):
+
+```
+pyside6-rcc icons.qrc -o rc_icons.py
+```
+
+The auto-generated `rc_icons.py` will be updated with the new/changed icons. Make sure to include this file in your pull request if you have modified any icons. Please also make sure to apply your changes to both the "light" and "dark" theme icons.

--- a/mne_qt_browser/_pg_figure.py
+++ b/mne_qt_browser/_pg_figure.py
@@ -125,8 +125,9 @@ from qtpy.QtWidgets import (
 )
 from scipy.stats import zscore
 
-from . import _browser_instances
-from ._fixes import _init_mne_qtapp, _qt_raise_window, capture_exceptions
+import mne_qt_browser.rc_icons  # noqa: F401
+from mne_qt_browser import _browser_instances
+from mne_qt_browser._fixes import _init_mne_qtapp, _qt_raise_window, capture_exceptions
 
 name = "pyqtgraph"
 
@@ -2595,9 +2596,9 @@ class AnnotationDock(QDockWidget):
         self.mne.visible_annotations[new_des] = self.mne.visible_annotations.pop(
             old_des
         )
-        self.mne.annotation_segment_colors[
-            new_des
-        ] = self.mne.annotation_segment_colors.pop(old_des)
+        self.mne.annotation_segment_colors[new_des] = (
+            self.mne.annotation_segment_colors.pop(old_des)
+        )
 
         # Update related widgets
         self.weakmain()._setup_annotation_colors()
@@ -2622,9 +2623,9 @@ class AnnotationDock(QDockWidget):
         if old_des not in self.mne.inst.annotations.description:
             self.mne.new_annotation_labels.remove(old_des)
             self.mne.visible_annotations.pop(old_des)
-            self.mne.annotation_segment_colors[
-                new_des
-            ] = self.mne.annotation_segment_colors.pop(old_des)
+            self.mne.annotation_segment_colors[new_des] = (
+                self.mne.annotation_segment_colors.pop(old_des)
+            )
 
         # Update related widgets
         self.weakmain()._setup_annotation_colors()
@@ -3104,7 +3105,6 @@ class MNEQtBrowser(BrowserBase, QMainWindow, metaclass=_PGMetaClass):
         self.mne.dark = cspace_convert(bgcolor, "sRGB1", "CIELab")[0] < 50
 
         # update icon theme
-        _qt_init_icons()
         if self.mne.dark:
             QIcon.setThemeName("dark")
         else:
@@ -5157,14 +5157,6 @@ def _setup_ipython(ipython=None):
 
         QtGui.QApplication.instance()
     return ipython
-
-
-def _qt_init_icons():
-    from qtpy.QtGui import QIcon
-
-    icons_path = f"{Path(__file__).parent}/icons"
-    QIcon.setThemeSearchPaths([icons_path])
-    return icons_path
 
 
 def _init_browser(**kwargs):

--- a/mne_qt_browser/icons.qrc
+++ b/mne_qt_browser/icons.qrc
@@ -1,0 +1,30 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="/">
+    <file>icons/dark/index.theme</file>
+    <file>icons/dark/actions/annotations.svg</file>
+    <file>icons/dark/actions/fullscreen.svg</file>
+    <file>icons/dark/actions/help.svg</file>
+    <file>icons/dark/actions/less_channels.svg</file>
+    <file>icons/dark/actions/less_time.svg</file>
+    <file>icons/dark/actions/more_channels.svg</file>
+    <file>icons/dark/actions/more_time.svg</file>
+    <file>icons/dark/actions/overview_bar.svg</file>
+    <file>icons/dark/actions/settings.svg</file>
+    <file>icons/dark/actions/ssp.svg</file>
+    <file>icons/dark/actions/zoom_in.svg</file>
+    <file>icons/dark/actions/zoom_out.svg</file>
+    <file>icons/light/index.theme</file>
+    <file>icons/light/actions/annotations.svg</file>
+    <file>icons/light/actions/fullscreen.svg</file>
+    <file>icons/light/actions/help.svg</file>
+    <file>icons/light/actions/less_channels.svg</file>
+    <file>icons/light/actions/less_time.svg</file>
+    <file>icons/light/actions/more_channels.svg</file>
+    <file>icons/light/actions/more_time.svg</file>
+    <file>icons/light/actions/overview_bar.svg</file>
+    <file>icons/light/actions/settings.svg</file>
+    <file>icons/light/actions/ssp.svg</file>
+    <file>icons/light/actions/zoom_in.svg</file>
+    <file>icons/light/actions/zoom_out.svg</file>
+</qresource>
+</RCC>

--- a/mne_qt_browser/icons/dark/index.theme
+++ b/mne_qt_browser/icons/dark/index.theme
@@ -1,6 +1,5 @@
 [Icon Theme]
 Name=dark
-
 Directories=actions
 
 [actions]

--- a/mne_qt_browser/icons/light/index.theme
+++ b/mne_qt_browser/icons/light/index.theme
@@ -1,6 +1,5 @@
 [Icon Theme]
 Name=light
-
 Directories=actions
 
 [actions]

--- a/mne_qt_browser/rc_icons.py
+++ b/mne_qt_browser/rc_icons.py
@@ -1,0 +1,1599 @@
+# Resource object code (Python 3)
+# Created by: object code
+# Created by: The Resource Compiler for Qt version 6.6.2
+# WARNING! All changes made in this file will be lost!
+
+from PySide6 import QtCore
+
+qt_resource_data = b"\
+\x00\x00\x00t\
+[\
+Icon Theme]\x0aName\
+=light\x0aDirectori\
+es=actions\x0a\x0a[act\
+ions]\x0aSize=32\x0aCo\
+ntext=Actions\x0aMi\
+nSize=16\x0aMaxSize\
+=128\x0aType=Scalab\
+le\x0a\
+\x00\x00\x07\xb7\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   heig\
+ht=\x2218px\x22\x0a   vie\
+wBox=\x220 0 24 24\x22\
+\x0a   width=\x2218px\x22\
+\x0a   fill=\x22#00000\
+0\x22\x0a   version=\x221\
+.1\x22\x0a   id=\x22svg6\x22\
+\x0a   sodipodi:doc\
+name=\x22less_chann\
+els_black_18dp.s\
+vg\x22\x0a   inkscape:\
+version=\x221.0.2-2\
+ (e86c870879, 20\
+21-01-15)\x22>\x0a  <m\
+etadata\x0a     id=\
+\x22metadata12\x22>\x0a  \
+  <rdf:RDF>\x0a    \
+  <cc:Work\x0a     \
+    rdf:about=\x22\x22\
+>\x0a        <dc:fo\
+rmat>image/svg+x\
+ml</dc:format>\x0a \
+       <dc:type\x0a\
+           rdf:r\
+esource=\x22http://\
+purl.org/dc/dcmi\
+type/StillImage\x22\
+ />\x0a        <dc:\
+title></dc:title\
+>\x0a      </cc:Wor\
+k>\x0a    </rdf:RDF\
+>\x0a  </metadata>\x0a\
+  <defs\x0a     id=\
+\x22defs10\x22 />\x0a  <s\
+odipodi:namedvie\
+w\x0a     pagecolor\
+=\x22#ffffff\x22\x0a     \
+bordercolor=\x22#66\
+6666\x22\x0a     borde\
+ropacity=\x221\x22\x0a   \
+  objecttoleranc\
+e=\x2210\x22\x0a     grid\
+tolerance=\x2210\x22\x0a \
+    guidetoleran\
+ce=\x2210\x22\x0a     ink\
+scape:pageopacit\
+y=\x220\x22\x0a     inksc\
+ape:pageshadow=\x22\
+2\x22\x0a     inkscape\
+:window-width=\x221\
+920\x22\x0a     inksca\
+pe:window-height\
+=\x221017\x22\x0a     id=\
+\x22namedview8\x22\x0a   \
+  showgrid=\x22fals\
+e\x22\x0a     inkscape\
+:zoom=\x2266.782307\
+\x22\x0a     inkscape:\
+cx=\x229.7099437\x22\x0a \
+    inkscape:cy=\
+\x227.3660085\x22\x0a    \
+ inkscape:window\
+-x=\x221912\x22\x0a     i\
+nkscape:window-y\
+=\x22-8\x22\x0a     inksc\
+ape:window-maxim\
+ized=\x221\x22\x0a     in\
+kscape:current-l\
+ayer=\x22svg6\x22\x0a    \
+ inkscape:docume\
+nt-rotation=\x220\x22 \
+/>\x0a  <path\x0a     \
+d=\x22M0 0h24v24H0V\
+0z\x22\x0a     fill=\x22n\
+one\x22\x0a     id=\x22pa\
+th2\x22 />\x0a  <path\x0a\
+     d=\x22M 3,15 H\
+ 21 V 13 H 3 Z m\
+ 0,4 H 21 V 17 H\
+ 3 Z M 3,11 H 20\
+.983176 V 9 H 3 \
+Z M 3,5 v 2 h 9.\
+372871 V 5 Z\x22\x0a  \
+   id=\x22path4\x22\x0a  \
+   sodipodi:node\
+types=\x22ccccccccc\
+ccccccccccc\x22 />\x0a\
+  <rect\x0a     sty\
+le=\x22fill:#000000\
+;stroke-width:93\
+.3333\x22\x0a     id=\x22\
+rect9\x22\x0a     widt\
+h=\x228.2088594\x22\x0a  \
+   height=\x221.641\
+7719\x22\x0a     x=\x2212\
+.765814\x22\x0a     y=\
+\x223.8497047\x22 />\x0a<\
+/svg>\x0a\
+\x00\x00\x01\xab\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#000\
+000\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M12 2C6.48 \
+2 2 6.48 2 12s4.\
+48 10 10 10 10-4\
+.48 10-10S17.52 \
+2 12 2zm1 17h-2v\
+-2h2v2zm2.07-7.7\
+5l-.9.92C13.45 1\
+2.9 13 13.5 13 1\
+5h-2v-.5c0-1.1.4\
+5-2.1 1.17-2.83l\
+1.24-1.26c.37-.3\
+6.59-.86.59-1.41\
+ 0-1.1-.9-2-2-2s\
+-2 .9-2 2H8c0-2.\
+21 1.79-4 4-4s4 \
+1.79 4 4c0 .88-.\
+36 1.68-.93 2.25\
+z\x22/></svg>\
+\x00\x00\x01Z\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 20 20\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 20 20\x22 width\
+=\x2218px\x22 fill=\x22#0\
+00000\x22><rect fil\
+l=\x22none\x22 height=\
+\x2220\x22 width=\x2220\x22/\
+><g><path d=\x22M3,\
+5v10h14V5H3z M7.\
+17,13.5H4.5v-7h2\
+.67V13.5z M11.33\
+,13.5H8.67v-2.75\
+h2.67V13.5z M15.\
+5,13.5h-2.67v-2.\
+75h2.67V13.5z M1\
+5.5,9.25H8.67V6.\
+5h6.83V9.25z\x22/><\
+/g></svg>\
+\x00\x00\x05\xb6\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#000\
+000\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M19.43 12.9\
+8c.04-.32.07-.64\
+.07-.98 0-.34-.0\
+3-.66-.07-.98l2.\
+11-1.65c.19-.15.\
+24-.42.12-.64l-2\
+-3.46c-.09-.16-.\
+26-.25-.44-.25-.\
+06 0-.12.01-.17.\
+03l-2.49 1c-.52-\
+.4-1.08-.73-1.69\
+-.98l-.38-2.65C1\
+4.46 2.18 14.25 \
+2 14 2h-4c-.25 0\
+-.46.18-.49.42l-\
+.38 2.65c-.61.25\
+-1.17.59-1.69.98\
+l-2.49-1c-.06-.0\
+2-.12-.03-.18-.0\
+3-.17 0-.34.09-.\
+43.25l-2 3.46c-.\
+13.22-.07.49.12.\
+64l2.11 1.65c-.0\
+4.32-.07.65-.07.\
+98 0 .33.03.66.0\
+7.98l-2.11 1.65c\
+-.19.15-.24.42-.\
+12.64l2 3.46c.09\
+.16.26.25.44.25.\
+06 0 .12-.01.17-\
+.03l2.49-1c.52.4\
+ 1.08.73 1.69.98\
+l.38 2.65c.03.24\
+.24.42.49.42h4c.\
+25 0 .46-.18.49-\
+.42l.38-2.65c.61\
+-.25 1.17-.59 1.\
+69-.98l2.49 1c.0\
+6.02.12.03.18.03\
+.17 0 .34-.09.43\
+-.25l2-3.46c.12-\
+.22.07-.49-.12-.\
+64l-2.11-1.65zm-\
+1.98-1.71c.04.31\
+.05.52.05.73 0 .\
+21-.02.43-.05.73\
+l-.14 1.13.89.7 \
+1.08.84-.7 1.21-\
+1.27-.51-1.04-.4\
+2-.9.68c-.43.32-\
+.84.56-1.25.73l-\
+1.06.43-.16 1.13\
+-.2 1.35h-1.4l-.\
+19-1.35-.16-1.13\
+-1.06-.43c-.43-.\
+18-.83-.41-1.23-\
+.71l-.91-.7-1.06\
+.43-1.27.51-.7-1\
+.21 1.08-.84.89-\
+.7-.14-1.13c-.03\
+-.31-.05-.54-.05\
+-.74s.02-.43.05-\
+.73l.14-1.13-.89\
+-.7-1.08-.84.7-1\
+.21 1.27.51 1.04\
+.42.9-.68c.43-.3\
+2.84-.56 1.25-.7\
+3l1.06-.43.16-1.\
+13.2-1.35h1.39l.\
+19 1.35.16 1.13 \
+1.06.43c.43.18.8\
+3.41 1.23.71l.91\
+.7 1.06-.43 1.27\
+-.51.7 1.21-1.07\
+.85-.89.7.14 1.1\
+3zM12 8c-2.21 0-\
+4 1.79-4 4s1.79 \
+4 4 4 4-1.79 4-4\
+-1.79-4-4-4zm0 6\
+c-1.1 0-2-.9-2-2\
+s.9-2 2-2 2 .9 2\
+ 2-.9 2-2 2z\x22/><\
+/svg>\
+\x00\x00\x07\xc1\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   heig\
+ht=\x2218px\x22\x0a   vie\
+wBox=\x220 0 24 24\x22\
+\x0a   width=\x2218px\x22\
+\x0a   fill=\x22#00000\
+0\x22\x0a   version=\x221\
+.1\x22\x0a   id=\x22svg6\x22\
+\x0a   sodipodi:doc\
+name=\x22more_chann\
+els_black_18dp.s\
+vg\x22\x0a   inkscape:\
+version=\x221.0.2-2\
+ (e86c870879, 20\
+21-01-15)\x22>\x0a  <m\
+etadata\x0a     id=\
+\x22metadata12\x22>\x0a  \
+  <rdf:RDF>\x0a    \
+  <cc:Work\x0a     \
+    rdf:about=\x22\x22\
+>\x0a        <dc:fo\
+rmat>image/svg+x\
+ml</dc:format>\x0a \
+       <dc:type\x0a\
+           rdf:r\
+esource=\x22http://\
+purl.org/dc/dcmi\
+type/StillImage\x22\
+ />\x0a        <dc:\
+title />\x0a      <\
+/cc:Work>\x0a    </\
+rdf:RDF>\x0a  </met\
+adata>\x0a  <defs\x0a \
+    id=\x22defs10\x22 \
+/>\x0a  <sodipodi:n\
+amedview\x0a     pa\
+gecolor=\x22#ffffff\
+\x22\x0a     bordercol\
+or=\x22#666666\x22\x0a   \
+  borderopacity=\
+\x221\x22\x0a     objectt\
+olerance=\x2210\x22\x0a  \
+   gridtolerance\
+=\x2210\x22\x0a     guide\
+tolerance=\x2210\x22\x0a \
+    inkscape:pag\
+eopacity=\x220\x22\x0a   \
+  inkscape:pages\
+hadow=\x222\x22\x0a     i\
+nkscape:window-w\
+idth=\x221920\x22\x0a    \
+ inkscape:window\
+-height=\x221017\x22\x0a \
+    id=\x22namedvie\
+w8\x22\x0a     showgri\
+d=\x22false\x22\x0a     i\
+nkscape:zoom=\x2233\
+.391153\x22\x0a     in\
+kscape:cx=\x222.896\
+5748\x22\x0a     inksc\
+ape:cy=\x229.633607\
+5\x22\x0a     inkscape\
+:window-x=\x221912\x22\
+\x0a     inkscape:w\
+indow-y=\x22-8\x22\x0a   \
+  inkscape:windo\
+w-maximized=\x221\x22\x0a\
+     inkscape:cu\
+rrent-layer=\x22svg\
+6\x22\x0a     inkscape\
+:document-rotati\
+on=\x220\x22 />\x0a  <pat\
+h\x0a     d=\x22M0 0h2\
+4v24H0V0z\x22\x0a     \
+fill=\x22none\x22\x0a    \
+ id=\x22path2\x22 />\x0a \
+ <path\x0a     d=\x22M\
+ 3,15 H 21 V 13 \
+H 3 Z m 0,4 H 21\
+ V 17 H 3 Z M 3,\
+11 H 20.983176 V\
+ 9 H 3 Z M 3,5 v\
+ 2 h 9.372871 V \
+5 Z\x22\x0a     id=\x22pa\
+th4\x22\x0a     sodipo\
+di:nodetypes=\x22cc\
+cccccccccccccccc\
+cc\x22 />\x0a  <polygo\
+n\x0a     points=\x221\
+7,6 15,6 15,4 14\
+,4 14,6 12,6 12,\
+7 14,7 14,9 15,9\
+ 15,7 17,7 \x22\x0a   \
+  id=\x22polygon10\x22\
+\x0a     transform=\
+\x22matrix(1.641772\
+,0,0,1.641772,-6\
+.9354495,-6.0009\
+274)\x22 />\x0a</svg>\x0a\
+\
+\x00\x00\x08\xcb\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   enab\
+le-background=\x22n\
+ew 0 0 20 20\x22\x0a  \
+ height=\x2218px\x22\x0a \
+  viewBox=\x220 0 2\
+0 20\x22\x0a   width=\x22\
+18px\x22\x0a   fill=\x22#\
+000000\x22\x0a   versi\
+on=\x221.1\x22\x0a   id=\x22\
+svg16\x22\x0a   sodipo\
+di:docname=\x22less\
+_time_black_18dp\
+.svg\x22\x0a   inkscap\
+e:version=\x221.0.2\
+-2 (e86c870879, \
+2021-01-15)\x22>\x0a  \
+<metadata\x0a     i\
+d=\x22metadata22\x22>\x0a\
+    <rdf:RDF>\x0a  \
+    <cc:Work\x0a   \
+      rdf:about=\
+\x22\x22>\x0a        <dc:\
+format>image/svg\
++xml</dc:format>\
+\x0a        <dc:typ\
+e\x0a           rdf\
+:resource=\x22http:\
+//purl.org/dc/dc\
+mitype/StillImag\
+e\x22 />\x0a        <d\
+c:title></dc:tit\
+le>\x0a      </cc:W\
+ork>\x0a    </rdf:R\
+DF>\x0a  </metadata\
+>\x0a  <defs\x0a     i\
+d=\x22defs20\x22 />\x0a  \
+<sodipodi:namedv\
+iew\x0a     pagecol\
+or=\x22#ffffff\x22\x0a   \
+  bordercolor=\x22#\
+666666\x22\x0a     bor\
+deropacity=\x221\x22\x0a \
+    objecttolera\
+nce=\x2210\x22\x0a     gr\
+idtolerance=\x2210\x22\
+\x0a     guidetoler\
+ance=\x2210\x22\x0a     i\
+nkscape:pageopac\
+ity=\x220\x22\x0a     ink\
+scape:pageshadow\
+=\x222\x22\x0a     inksca\
+pe:window-width=\
+\x221920\x22\x0a     inks\
+cape:window-heig\
+ht=\x221017\x22\x0a     i\
+d=\x22namedview18\x22\x0a\
+     showgrid=\x22f\
+alse\x22\x0a     inksc\
+ape:zoom=\x2294.444\
+444\x22\x0a     inksca\
+pe:cx=\x2210.855011\
+\x22\x0a     inkscape:\
+cy=\x227.4710726\x22\x0a \
+    inkscape:win\
+dow-x=\x22-8\x22\x0a     \
+inkscape:window-\
+y=\x22-8\x22\x0a     inks\
+cape:window-maxi\
+mized=\x221\x22\x0a     i\
+nkscape:current-\
+layer=\x22svg16\x22 />\
+\x0a  <g\x0a     id=\x22g\
+4\x22>\x0a    <rect\x0a  \
+     fill=\x22none\x22\
+\x0a       height=\x22\
+20\x22\x0a       width\
+=\x2220\x22\x0a       x=\x22\
+0\x22\x0a       id=\x22re\
+ct2\x22 />\x0a  </g>\x0a \
+ <g\x0a     id=\x22g14\
+\x22>\x0a    <g\x0a      \
+ id=\x22g12\x22>\x0a     \
+ <polygon\x0a      \
+   points=\x228.5,8\
+.05 8.5,12.05 11\
+.67,13.95 12.17,\
+13.13 9.5,11.55 \
+9.5,8.05\x22\x0a      \
+   id=\x22polygon6\x22\
+ />\x0a      <path\x0a\
+         d=\x22M13.\
+9,10c0.07,0.32,0\
+.1,0.66,0.1,1c0,\
+2.76-2.24,5-5,5s\
+-5-2.24-5-5s2.24\
+-5,5-5c0.71,0,1.\
+39,0.15,2,0.42V5\
+.35 C10.37,5.13,\
+9.7,5,9,5c-3.31,\
+0-6,2.69-6,6s2.6\
+9,6,6,6s6-2.69,6\
+-6c0-0.34-0.04-0\
+.67-0.09-1H13.9z\
+\x22\x0a         id=\x22p\
+ath8\x22 />\x0a    </g\
+>\x0a  </g>\x0a  <rect\
+\x0a     style=\x22fil\
+l:#000000;stroke\
+-width:77.7778\x22\x0a\
+     id=\x22rect24\x22\
+\x0a     width=\x225\x22\x0a\
+     height=\x220.9\
+9999994\x22\x0a     x=\
+\x2212\x22\x0a     y=\x226\x22 \
+/>\x0a</svg>\x0a\
+\x00\x00\x01\x17\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#0\
+00000\x22><rect fil\
+l=\x22none\x22 height=\
+\x2224\x22 width=\x2224\x22/\
+><polygon points\
+=\x2221,11 21,3 13,\
+3 16.29,6.29 6.2\
+9,16.29 3,13 3,2\
+1 11,21 7.71,17.\
+71 17.71,7.71\x22/>\
+</svg>\
+\x00\x00\x02M\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 20 20\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 20 20\x22 width\
+=\x2218px\x22 fill=\x22#0\
+00000\x22><g><rect \
+fill=\x22none\x22 heig\
+ht=\x2220\x22 width=\x222\
+0\x22 x=\x220\x22/></g><g\
+><g><polygon poi\
+nts=\x228.5,8.05 8.\
+5,12.05 11.67,13\
+.95 12.17,13.13 \
+9.5,11.55 9.5,8.\
+05\x22/><path d=\x22M1\
+3.9,10c0.07,0.32\
+,0.1,0.66,0.1,1c\
+0,2.76-2.24,5-5,\
+5s-5-2.24-5-5s2.\
+24-5,5-5c0.71,0,\
+1.39,0.15,2,0.42\
+V5.35 C10.37,5.1\
+3,9.7,5,9,5c-3.3\
+1,0-6,2.69-6,6s2\
+.69,6,6,6s6-2.69\
+,6-6c0-0.34-0.04\
+-0.67-0.09-1H13.\
+9z\x22/><polygon po\
+ints=\x2215,6 15,4 \
+14,4 14,6 14,6 1\
+2,6 12,7 14,7 14\
+,9 15,9 15,7 15,\
+7 17,7 17,6\x22/></\
+g></g></svg>\
+\x00\x00\x01\xf4\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#0\
+00000\x22><g><rect \
+fill=\x22none\x22 heig\
+ht=\x2224\x22 width=\x222\
+4\x22/></g><g><g><p\
+ath d=\x22M16.81,8.\
+94l-3.75-3.75L4,\
+14.25V18h3.75L16\
+.81,8.94z M6,16v\
+-0.92l7.06-7.06l\
+0.92,0.92L6.92,1\
+6H6z\x22/><path d=\x22\
+M19.71,6.04c0.39\
+-0.39,0.39-1.02,\
+0-1.41l-2.34-2.3\
+4C17.17,2.09,16.\
+92,2,16.66,2c-0.\
+25,0-0.51,0.1-0.\
+7,0.29l-1.83,1.8\
+3 l3.75,3.75L19.\
+71,6.04z\x22/><rect\
+ height=\x224\x22 widt\
+h=\x2220\x22 x=\x222\x22 y=\x22\
+20\x22/></g></g></s\
+vg>\
+\x00\x00\x01\x94\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#000\
+000\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M15.5 14h-.\
+79l-.28-.27C15.4\
+1 12.59 16 11.11\
+ 16 9.5 16 5.91 \
+13.09 3 9.5 3S3 \
+5.91 3 9.5 5.91 \
+16 9.5 16c1.61 0\
+ 3.09-.59 4.23-1\
+.57l.27.28v.79l5\
+ 4.99L20.49 19l-\
+4.99-5zm-6 0C7.0\
+1 14 5 11.99 5 9\
+.5S7.01 5 9.5 5 \
+14 7.01 14 9.5 1\
+1.99 14 9.5 14zM\
+7 9h5v1H7z\x22/></s\
+vg>\
+\x00\x00\x00\xf1\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#0\
+00000\x22><rect fil\
+l=\x22none\x22 height=\
+\x2224\x22 width=\x2224\x22/\
+><path d=\x22M9,5v2\
+h6.59L4,18.59L5.\
+41,20L17,8.41V15\
+h2V5H9z\x22/></svg>\
+\
+\x00\x00\x01\xa7\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#000\
+000\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M15.5 14h-.\
+79l-.28-.27C15.4\
+1 12.59 16 11.11\
+ 16 9.5 16 5.91 \
+13.09 3 9.5 3S3 \
+5.91 3 9.5 5.91 \
+16 9.5 16c1.61 0\
+ 3.09-.59 4.23-1\
+.57l.27.28v.79l5\
+ 4.99L20.49 19l-\
+4.99-5zm-6 0C7.0\
+1 14 5 11.99 5 9\
+.5S7.01 5 9.5 5 \
+14 7.01 14 9.5 1\
+1.99 14 9.5 14zm\
+.5-7H9v2H7v1h2v2\
+h1v-2h2V9h-2z\x22/>\
+</svg>\
+\x00\x00\x00s\
+[\
+Icon Theme]\x0aName\
+=dark\x0aDirectorie\
+s=actions\x0a\x0a[acti\
+ons]\x0aSize=32\x0aCon\
+text=Actions\x0aMin\
+Size=16\x0aMaxSize=\
+128\x0aType=Scalabl\
+e\x0a\
+\x00\x00\x07\xb7\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   heig\
+ht=\x2218px\x22\x0a   vie\
+wBox=\x220 0 24 24\x22\
+\x0a   width=\x2218px\x22\
+\x0a   fill=\x22#fffff\
+f\x22\x0a   version=\x221\
+.1\x22\x0a   id=\x22svg6\x22\
+\x0a   sodipodi:doc\
+name=\x22less_chann\
+els_black_18dp.s\
+vg\x22\x0a   inkscape:\
+version=\x221.0.2-2\
+ (e86c870879, 20\
+21-01-15)\x22>\x0a  <m\
+etadata\x0a     id=\
+\x22metadata12\x22>\x0a  \
+  <rdf:RDF>\x0a    \
+  <cc:Work\x0a     \
+    rdf:about=\x22\x22\
+>\x0a        <dc:fo\
+rmat>image/svg+x\
+ml</dc:format>\x0a \
+       <dc:type\x0a\
+           rdf:r\
+esource=\x22http://\
+purl.org/dc/dcmi\
+type/StillImage\x22\
+ />\x0a        <dc:\
+title></dc:title\
+>\x0a      </cc:Wor\
+k>\x0a    </rdf:RDF\
+>\x0a  </metadata>\x0a\
+  <defs\x0a     id=\
+\x22defs10\x22 />\x0a  <s\
+odipodi:namedvie\
+w\x0a     pagecolor\
+=\x22#ffffff\x22\x0a     \
+bordercolor=\x22#66\
+6666\x22\x0a     borde\
+ropacity=\x221\x22\x0a   \
+  objecttoleranc\
+e=\x2210\x22\x0a     grid\
+tolerance=\x2210\x22\x0a \
+    guidetoleran\
+ce=\x2210\x22\x0a     ink\
+scape:pageopacit\
+y=\x220\x22\x0a     inksc\
+ape:pageshadow=\x22\
+2\x22\x0a     inkscape\
+:window-width=\x221\
+920\x22\x0a     inksca\
+pe:window-height\
+=\x221017\x22\x0a     id=\
+\x22namedview8\x22\x0a   \
+  showgrid=\x22fals\
+e\x22\x0a     inkscape\
+:zoom=\x2266.782307\
+\x22\x0a     inkscape:\
+cx=\x229.7099437\x22\x0a \
+    inkscape:cy=\
+\x227.3660085\x22\x0a    \
+ inkscape:window\
+-x=\x221912\x22\x0a     i\
+nkscape:window-y\
+=\x22-8\x22\x0a     inksc\
+ape:window-maxim\
+ized=\x221\x22\x0a     in\
+kscape:current-l\
+ayer=\x22svg6\x22\x0a    \
+ inkscape:docume\
+nt-rotation=\x220\x22 \
+/>\x0a  <path\x0a     \
+d=\x22M0 0h24v24H0V\
+0z\x22\x0a     fill=\x22n\
+one\x22\x0a     id=\x22pa\
+th2\x22 />\x0a  <path\x0a\
+     d=\x22M 3,15 H\
+ 21 V 13 H 3 Z m\
+ 0,4 H 21 V 17 H\
+ 3 Z M 3,11 H 20\
+.983176 V 9 H 3 \
+Z M 3,5 v 2 h 9.\
+372871 V 5 Z\x22\x0a  \
+   id=\x22path4\x22\x0a  \
+   sodipodi:node\
+types=\x22ccccccccc\
+ccccccccccc\x22 />\x0a\
+  <rect\x0a     sty\
+le=\x22fill:#ffffff\
+;stroke-width:93\
+.3333\x22\x0a     id=\x22\
+rect9\x22\x0a     widt\
+h=\x228.2088594\x22\x0a  \
+   height=\x221.641\
+7719\x22\x0a     x=\x2212\
+.765814\x22\x0a     y=\
+\x223.8497047\x22 />\x0a<\
+/svg>\x0a\
+\x00\x00\x01\xab\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#FFF\
+FFF\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M12 2C6.48 \
+2 2 6.48 2 12s4.\
+48 10 10 10 10-4\
+.48 10-10S17.52 \
+2 12 2zm1 17h-2v\
+-2h2v2zm2.07-7.7\
+5l-.9.92C13.45 1\
+2.9 13 13.5 13 1\
+5h-2v-.5c0-1.1.4\
+5-2.1 1.17-2.83l\
+1.24-1.26c.37-.3\
+6.59-.86.59-1.41\
+ 0-1.1-.9-2-2-2s\
+-2 .9-2 2H8c0-2.\
+21 1.79-4 4-4s4 \
+1.79 4 4c0 .88-.\
+36 1.68-.93 2.25\
+z\x22/></svg>\
+\x00\x00\x01Z\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 20 20\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 20 20\x22 width\
+=\x2218px\x22 fill=\x22#F\
+FFFFF\x22><rect fil\
+l=\x22none\x22 height=\
+\x2220\x22 width=\x2220\x22/\
+><g><path d=\x22M3,\
+5v10h14V5H3z M7.\
+17,13.5H4.5v-7h2\
+.67V13.5z M11.33\
+,13.5H8.67v-2.75\
+h2.67V13.5z M15.\
+5,13.5h-2.67v-2.\
+75h2.67V13.5z M1\
+5.5,9.25H8.67V6.\
+5h6.83V9.25z\x22/><\
+/g></svg>\
+\x00\x00\x05\xb6\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#FFF\
+FFF\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M19.43 12.9\
+8c.04-.32.07-.64\
+.07-.98 0-.34-.0\
+3-.66-.07-.98l2.\
+11-1.65c.19-.15.\
+24-.42.12-.64l-2\
+-3.46c-.09-.16-.\
+26-.25-.44-.25-.\
+06 0-.12.01-.17.\
+03l-2.49 1c-.52-\
+.4-1.08-.73-1.69\
+-.98l-.38-2.65C1\
+4.46 2.18 14.25 \
+2 14 2h-4c-.25 0\
+-.46.18-.49.42l-\
+.38 2.65c-.61.25\
+-1.17.59-1.69.98\
+l-2.49-1c-.06-.0\
+2-.12-.03-.18-.0\
+3-.17 0-.34.09-.\
+43.25l-2 3.46c-.\
+13.22-.07.49.12.\
+64l2.11 1.65c-.0\
+4.32-.07.65-.07.\
+98 0 .33.03.66.0\
+7.98l-2.11 1.65c\
+-.19.15-.24.42-.\
+12.64l2 3.46c.09\
+.16.26.25.44.25.\
+06 0 .12-.01.17-\
+.03l2.49-1c.52.4\
+ 1.08.73 1.69.98\
+l.38 2.65c.03.24\
+.24.42.49.42h4c.\
+25 0 .46-.18.49-\
+.42l.38-2.65c.61\
+-.25 1.17-.59 1.\
+69-.98l2.49 1c.0\
+6.02.12.03.18.03\
+.17 0 .34-.09.43\
+-.25l2-3.46c.12-\
+.22.07-.49-.12-.\
+64l-2.11-1.65zm-\
+1.98-1.71c.04.31\
+.05.52.05.73 0 .\
+21-.02.43-.05.73\
+l-.14 1.13.89.7 \
+1.08.84-.7 1.21-\
+1.27-.51-1.04-.4\
+2-.9.68c-.43.32-\
+.84.56-1.25.73l-\
+1.06.43-.16 1.13\
+-.2 1.35h-1.4l-.\
+19-1.35-.16-1.13\
+-1.06-.43c-.43-.\
+18-.83-.41-1.23-\
+.71l-.91-.7-1.06\
+.43-1.27.51-.7-1\
+.21 1.08-.84.89-\
+.7-.14-1.13c-.03\
+-.31-.05-.54-.05\
+-.74s.02-.43.05-\
+.73l.14-1.13-.89\
+-.7-1.08-.84.7-1\
+.21 1.27.51 1.04\
+.42.9-.68c.43-.3\
+2.84-.56 1.25-.7\
+3l1.06-.43.16-1.\
+13.2-1.35h1.39l.\
+19 1.35.16 1.13 \
+1.06.43c.43.18.8\
+3.41 1.23.71l.91\
+.7 1.06-.43 1.27\
+-.51.7 1.21-1.07\
+.85-.89.7.14 1.1\
+3zM12 8c-2.21 0-\
+4 1.79-4 4s1.79 \
+4 4 4 4-1.79 4-4\
+-1.79-4-4-4zm0 6\
+c-1.1 0-2-.9-2-2\
+s.9-2 2-2 2 .9 2\
+ 2-.9 2-2 2z\x22/><\
+/svg>\
+\x00\x00\x07\xc1\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   heig\
+ht=\x2218px\x22\x0a   vie\
+wBox=\x220 0 24 24\x22\
+\x0a   width=\x2218px\x22\
+\x0a   fill=\x22#fffff\
+f\x22\x0a   version=\x221\
+.1\x22\x0a   id=\x22svg6\x22\
+\x0a   sodipodi:doc\
+name=\x22more_chann\
+els_black_18dp.s\
+vg\x22\x0a   inkscape:\
+version=\x221.0.2-2\
+ (e86c870879, 20\
+21-01-15)\x22>\x0a  <m\
+etadata\x0a     id=\
+\x22metadata12\x22>\x0a  \
+  <rdf:RDF>\x0a    \
+  <cc:Work\x0a     \
+    rdf:about=\x22\x22\
+>\x0a        <dc:fo\
+rmat>image/svg+x\
+ml</dc:format>\x0a \
+       <dc:type\x0a\
+           rdf:r\
+esource=\x22http://\
+purl.org/dc/dcmi\
+type/StillImage\x22\
+ />\x0a        <dc:\
+title />\x0a      <\
+/cc:Work>\x0a    </\
+rdf:RDF>\x0a  </met\
+adata>\x0a  <defs\x0a \
+    id=\x22defs10\x22 \
+/>\x0a  <sodipodi:n\
+amedview\x0a     pa\
+gecolor=\x22#ffffff\
+\x22\x0a     bordercol\
+or=\x22#666666\x22\x0a   \
+  borderopacity=\
+\x221\x22\x0a     objectt\
+olerance=\x2210\x22\x0a  \
+   gridtolerance\
+=\x2210\x22\x0a     guide\
+tolerance=\x2210\x22\x0a \
+    inkscape:pag\
+eopacity=\x220\x22\x0a   \
+  inkscape:pages\
+hadow=\x222\x22\x0a     i\
+nkscape:window-w\
+idth=\x221920\x22\x0a    \
+ inkscape:window\
+-height=\x221017\x22\x0a \
+    id=\x22namedvie\
+w8\x22\x0a     showgri\
+d=\x22false\x22\x0a     i\
+nkscape:zoom=\x2233\
+.391153\x22\x0a     in\
+kscape:cx=\x222.896\
+5748\x22\x0a     inksc\
+ape:cy=\x229.633607\
+5\x22\x0a     inkscape\
+:window-x=\x221912\x22\
+\x0a     inkscape:w\
+indow-y=\x22-8\x22\x0a   \
+  inkscape:windo\
+w-maximized=\x221\x22\x0a\
+     inkscape:cu\
+rrent-layer=\x22svg\
+6\x22\x0a     inkscape\
+:document-rotati\
+on=\x220\x22 />\x0a  <pat\
+h\x0a     d=\x22M0 0h2\
+4v24H0V0z\x22\x0a     \
+fill=\x22none\x22\x0a    \
+ id=\x22path2\x22 />\x0a \
+ <path\x0a     d=\x22M\
+ 3,15 H 21 V 13 \
+H 3 Z m 0,4 H 21\
+ V 17 H 3 Z M 3,\
+11 H 20.983176 V\
+ 9 H 3 Z M 3,5 v\
+ 2 h 9.372871 V \
+5 Z\x22\x0a     id=\x22pa\
+th4\x22\x0a     sodipo\
+di:nodetypes=\x22cc\
+cccccccccccccccc\
+cc\x22 />\x0a  <polygo\
+n\x0a     points=\x221\
+7,6 15,6 15,4 14\
+,4 14,6 12,6 12,\
+7 14,7 14,9 15,9\
+ 15,7 17,7 \x22\x0a   \
+  id=\x22polygon10\x22\
+\x0a     transform=\
+\x22matrix(1.641772\
+,0,0,1.641772,-6\
+.9354495,-6.0009\
+274)\x22 />\x0a</svg>\x0a\
+\
+\x00\x00\x08\xcb\
+<\
+?xml version=\x221.\
+0\x22 encoding=\x22UTF\
+-8\x22 standalone=\x22\
+no\x22?>\x0a<svg\x0a   xm\
+lns:dc=\x22http://p\
+url.org/dc/eleme\
+nts/1.1/\x22\x0a   xml\
+ns:cc=\x22http://cr\
+eativecommons.or\
+g/ns#\x22\x0a   xmlns:\
+rdf=\x22http://www.\
+w3.org/1999/02/2\
+2-rdf-syntax-ns#\
+\x22\x0a   xmlns:svg=\x22\
+http://www.w3.or\
+g/2000/svg\x22\x0a   x\
+mlns=\x22http://www\
+.w3.org/2000/svg\
+\x22\x0a   xmlns:sodip\
+odi=\x22http://sodi\
+podi.sourceforge\
+.net/DTD/sodipod\
+i-0.dtd\x22\x0a   xmln\
+s:inkscape=\x22http\
+://www.inkscape.\
+org/namespaces/i\
+nkscape\x22\x0a   enab\
+le-background=\x22n\
+ew 0 0 20 20\x22\x0a  \
+ height=\x2218px\x22\x0a \
+  viewBox=\x220 0 2\
+0 20\x22\x0a   width=\x22\
+18px\x22\x0a   fill=\x22#\
+ffffff\x22\x0a   versi\
+on=\x221.1\x22\x0a   id=\x22\
+svg16\x22\x0a   sodipo\
+di:docname=\x22less\
+_time_black_18dp\
+.svg\x22\x0a   inkscap\
+e:version=\x221.0.2\
+-2 (e86c870879, \
+2021-01-15)\x22>\x0a  \
+<metadata\x0a     i\
+d=\x22metadata22\x22>\x0a\
+    <rdf:RDF>\x0a  \
+    <cc:Work\x0a   \
+      rdf:about=\
+\x22\x22>\x0a        <dc:\
+format>image/svg\
++xml</dc:format>\
+\x0a        <dc:typ\
+e\x0a           rdf\
+:resource=\x22http:\
+//purl.org/dc/dc\
+mitype/StillImag\
+e\x22 />\x0a        <d\
+c:title></dc:tit\
+le>\x0a      </cc:W\
+ork>\x0a    </rdf:R\
+DF>\x0a  </metadata\
+>\x0a  <defs\x0a     i\
+d=\x22defs20\x22 />\x0a  \
+<sodipodi:namedv\
+iew\x0a     pagecol\
+or=\x22#ffffff\x22\x0a   \
+  bordercolor=\x22#\
+666666\x22\x0a     bor\
+deropacity=\x221\x22\x0a \
+    objecttolera\
+nce=\x2210\x22\x0a     gr\
+idtolerance=\x2210\x22\
+\x0a     guidetoler\
+ance=\x2210\x22\x0a     i\
+nkscape:pageopac\
+ity=\x220\x22\x0a     ink\
+scape:pageshadow\
+=\x222\x22\x0a     inksca\
+pe:window-width=\
+\x221920\x22\x0a     inks\
+cape:window-heig\
+ht=\x221017\x22\x0a     i\
+d=\x22namedview18\x22\x0a\
+     showgrid=\x22f\
+alse\x22\x0a     inksc\
+ape:zoom=\x2294.444\
+444\x22\x0a     inksca\
+pe:cx=\x2210.855011\
+\x22\x0a     inkscape:\
+cy=\x227.4710726\x22\x0a \
+    inkscape:win\
+dow-x=\x22-8\x22\x0a     \
+inkscape:window-\
+y=\x22-8\x22\x0a     inks\
+cape:window-maxi\
+mized=\x221\x22\x0a     i\
+nkscape:current-\
+layer=\x22svg16\x22 />\
+\x0a  <g\x0a     id=\x22g\
+4\x22>\x0a    <rect\x0a  \
+     fill=\x22none\x22\
+\x0a       height=\x22\
+20\x22\x0a       width\
+=\x2220\x22\x0a       x=\x22\
+0\x22\x0a       id=\x22re\
+ct2\x22 />\x0a  </g>\x0a \
+ <g\x0a     id=\x22g14\
+\x22>\x0a    <g\x0a      \
+ id=\x22g12\x22>\x0a     \
+ <polygon\x0a      \
+   points=\x228.5,8\
+.05 8.5,12.05 11\
+.67,13.95 12.17,\
+13.13 9.5,11.55 \
+9.5,8.05\x22\x0a      \
+   id=\x22polygon6\x22\
+ />\x0a      <path\x0a\
+         d=\x22M13.\
+9,10c0.07,0.32,0\
+.1,0.66,0.1,1c0,\
+2.76-2.24,5-5,5s\
+-5-2.24-5-5s2.24\
+-5,5-5c0.71,0,1.\
+39,0.15,2,0.42V5\
+.35 C10.37,5.13,\
+9.7,5,9,5c-3.31,\
+0-6,2.69-6,6s2.6\
+9,6,6,6s6-2.69,6\
+-6c0-0.34-0.04-0\
+.67-0.09-1H13.9z\
+\x22\x0a         id=\x22p\
+ath8\x22 />\x0a    </g\
+>\x0a  </g>\x0a  <rect\
+\x0a     style=\x22fil\
+l:#ffffff;stroke\
+-width:77.7778\x22\x0a\
+     id=\x22rect24\x22\
+\x0a     width=\x225\x22\x0a\
+     height=\x220.9\
+9999994\x22\x0a     x=\
+\x2212\x22\x0a     y=\x226\x22 \
+/>\x0a</svg>\x0a\
+\x00\x00\x01\x17\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#F\
+FFFFF\x22><rect fil\
+l=\x22none\x22 height=\
+\x2224\x22 width=\x2224\x22/\
+><polygon points\
+=\x2221,11 21,3 13,\
+3 16.29,6.29 6.2\
+9,16.29 3,13 3,2\
+1 11,21 7.71,17.\
+71 17.71,7.71\x22/>\
+</svg>\
+\x00\x00\x02M\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 20 20\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 20 20\x22 width\
+=\x2218px\x22 fill=\x22#F\
+FFFFF\x22><g><rect \
+fill=\x22none\x22 heig\
+ht=\x2220\x22 width=\x222\
+0\x22 x=\x220\x22/></g><g\
+><g><polygon poi\
+nts=\x228.5,8.05 8.\
+5,12.05 11.67,13\
+.95 12.17,13.13 \
+9.5,11.55 9.5,8.\
+05\x22/><path d=\x22M1\
+3.9,10c0.07,0.32\
+,0.1,0.66,0.1,1c\
+0,2.76-2.24,5-5,\
+5s-5-2.24-5-5s2.\
+24-5,5-5c0.71,0,\
+1.39,0.15,2,0.42\
+V5.35 C10.37,5.1\
+3,9.7,5,9,5c-3.3\
+1,0-6,2.69-6,6s2\
+.69,6,6,6s6-2.69\
+,6-6c0-0.34-0.04\
+-0.67-0.09-1H13.\
+9z\x22/><polygon po\
+ints=\x2215,6 15,4 \
+14,4 14,6 14,6 1\
+2,6 12,7 14,7 14\
+,9 15,9 15,7 15,\
+7 17,7 17,6\x22/></\
+g></g></svg>\
+\x00\x00\x01\xf4\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#F\
+FFFFF\x22><g><rect \
+fill=\x22none\x22 heig\
+ht=\x2224\x22 width=\x222\
+4\x22/></g><g><g><p\
+ath d=\x22M16.81,8.\
+94l-3.75-3.75L4,\
+14.25V18h3.75L16\
+.81,8.94z M6,16v\
+-0.92l7.06-7.06l\
+0.92,0.92L6.92,1\
+6H6z\x22/><path d=\x22\
+M19.71,6.04c0.39\
+-0.39,0.39-1.02,\
+0-1.41l-2.34-2.3\
+4C17.17,2.09,16.\
+92,2,16.66,2c-0.\
+25,0-0.51,0.1-0.\
+7,0.29l-1.83,1.8\
+3 l3.75,3.75L19.\
+71,6.04z\x22/><rect\
+ height=\x224\x22 widt\
+h=\x2220\x22 x=\x222\x22 y=\x22\
+20\x22/></g></g></s\
+vg>\
+\x00\x00\x01\x94\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#FFF\
+FFF\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M15.5 14h-.\
+79l-.28-.27C15.4\
+1 12.59 16 11.11\
+ 16 9.5 16 5.91 \
+13.09 3 9.5 3S3 \
+5.91 3 9.5 5.91 \
+16 9.5 16c1.61 0\
+ 3.09-.59 4.23-1\
+.57l.27.28v.79l5\
+ 4.99L20.49 19l-\
+4.99-5zm-6 0C7.0\
+1 14 5 11.99 5 9\
+.5S7.01 5 9.5 5 \
+14 7.01 14 9.5 1\
+1.99 14 9.5 14zM\
+7 9h5v1H7z\x22/></s\
+vg>\
+\x00\x00\x00\xf1\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 enable-ba\
+ckground=\x22new 0 \
+0 24 24\x22 height=\
+\x2218px\x22 viewBox=\x22\
+0 0 24 24\x22 width\
+=\x2218px\x22 fill=\x22#F\
+FFFFF\x22><rect fil\
+l=\x22none\x22 height=\
+\x2224\x22 width=\x2224\x22/\
+><path d=\x22M9,5v2\
+h6.59L4,18.59L5.\
+41,20L17,8.41V15\
+h2V5H9z\x22/></svg>\
+\
+\x00\x00\x01\xa7\
+<\
+svg xmlns=\x22http:\
+//www.w3.org/200\
+0/svg\x22 height=\x221\
+8px\x22 viewBox=\x220 \
+0 24 24\x22 width=\x22\
+18px\x22 fill=\x22#FFF\
+FFF\x22><path d=\x22M0\
+ 0h24v24H0V0z\x22 f\
+ill=\x22none\x22/><pat\
+h d=\x22M15.5 14h-.\
+79l-.28-.27C15.4\
+1 12.59 16 11.11\
+ 16 9.5 16 5.91 \
+13.09 3 9.5 3S3 \
+5.91 3 9.5 5.91 \
+16 9.5 16c1.61 0\
+ 3.09-.59 4.23-1\
+.57l.27.28v.79l5\
+ 4.99L20.49 19l-\
+4.99-5zm-6 0C7.0\
+1 14 5 11.99 5 9\
+.5S7.01 5 9.5 5 \
+14 7.01 14 9.5 1\
+1.99 14 9.5 14zm\
+.5-7H9v2H7v1h2v2\
+h1v-2h2V9h-2z\x22/>\
+</svg>\
+"
+
+qt_resource_name = b"\
+\x00\x05\
+\x00o\xa6S\
+\x00i\
+\x00c\x00o\x00n\x00s\
+\x00\x04\
+\x00\x06\xa8\x8b\
+\x00d\
+\x00a\x00r\x00k\
+\x00\x05\
+\x00r\xfd\xf4\
+\x00l\
+\x00i\x00g\x00h\x00t\
+\x00\x0b\
+\x0b\xba\x81\xb5\
+\x00i\
+\x00n\x00d\x00e\x00x\x00.\x00t\x00h\x00e\x00m\x00e\
+\x00\x07\
+\x07\xab\x06\x93\
+\x00a\
+\x00c\x00t\x00i\x00o\x00n\x00s\
+\x00\x11\
+\x02\xcez\x07\
+\x00l\
+\x00e\x00s\x00s\x00_\x00c\x00h\x00a\x00n\x00n\x00e\x00l\x00s\x00.\x00s\x00v\x00g\
+\
+\x00\x08\
+\x0c3W\x07\
+\x00h\
+\x00e\x00l\x00p\x00.\x00s\x00v\x00g\
+\x00\x10\
+\x0b\x07sG\
+\x00o\
+\x00v\x00e\x00r\x00v\x00i\x00e\x00w\x00_\x00b\x00a\x00r\x00.\x00s\x00v\x00g\
+\x00\x0c\
+\x0b\xdf,\xc7\
+\x00s\
+\x00e\x00t\x00t\x00i\x00n\x00g\x00s\x00.\x00s\x00v\x00g\
+\x00\x11\
+\x02\xdb\xf2\x87\
+\x00m\
+\x00o\x00r\x00e\x00_\x00c\x00h\x00a\x00n\x00n\x00e\x00l\x00s\x00.\x00s\x00v\x00g\
+\
+\x00\x0d\
+\x0d\xa5vG\
+\x00l\
+\x00e\x00s\x00s\x00_\x00t\x00i\x00m\x00e\x00.\x00s\x00v\x00g\
+\x00\x0e\
+\x03\xe6t\xa7\
+\x00f\
+\x00u\x00l\x00l\x00s\x00c\x00r\x00e\x00e\x00n\x00.\x00s\x00v\x00g\
+\x00\x0d\
+\x08\xe96G\
+\x00m\
+\x00o\x00r\x00e\x00_\x00t\x00i\x00m\x00e\x00.\x00s\x00v\x00g\
+\x00\x0f\
+\x00\x82\xee'\
+\x00a\
+\x00n\x00n\x00o\x00t\x00a\x00t\x00i\x00o\x00n\x00s\x00.\x00s\x00v\x00g\
+\x00\x0c\
+\x06\xeb\x9c'\
+\x00z\
+\x00o\x00o\x00m\x00_\x00o\x00u\x00t\x00.\x00s\x00v\x00g\
+\x00\x07\
+\x0a\xa3Z'\
+\x00s\
+\x00s\x00p\x00.\x00s\x00v\x00g\
+\x00\x0b\
+\x05\x03\x96\xa7\
+\x00z\
+\x00o\x00o\x00m\x00_\x00i\x00n\x00.\x00s\x00v\x00g\
+"
+
+qt_resource_struct = b"\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x01\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x02\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x10\x00\x02\x00\x00\x00\x02\x00\x00\x00\x12\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00\x1e\x00\x02\x00\x00\x00\x02\x00\x00\x00\x04\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00J\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x06\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00.\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\
+\x00\x00\x01\x8d\xf9 E\x8c\
+\x00\x00\x01j\x00\x00\x00\x00\x00\x01\x00\x00$\xfa\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x00^\x00\x00\x00\x00\x00\x01\x00\x00\x00x\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x00\xe0\x00\x00\x00\x00\x00\x01\x00\x00\x10\xfa\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x01(\x00\x00\x00\x00\x00\x01\x00\x00!\x8e\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x01\xc0\x00\x00\x00\x00\x00\x01\x00\x00)\x7f\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x01\x8e\x00\x00\x00\x00\x00\x01\x00\x00&\xf2\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x01J\x00\x00\x00\x00\x00\x01\x00\x00\x22\xa9\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x01\xac\x00\x00\x00\x00\x00\x01\x00\x00(\x8a\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x00\x9c\x00\x00\x00\x00\x00\x01\x00\x00\x09\xe2\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x00\xc2\x00\x00\x00\x00\x00\x01\x00\x00\x0b@\
+\x00\x00\x01\x8d\xf5\xaf\x80!\
+\x00\x00\x00\x86\x00\x00\x00\x00\x00\x01\x00\x00\x083\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x01\x08\x00\x00\x00\x00\x00\x01\x00\x00\x18\xbf\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x00J\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x14\
+\x00\x00\x00\x00\x00\x00\x00\x00\
+\x00\x00\x00.\x00\x00\x00\x00\x00\x01\x00\x00+*\
+\x00\x00\x01\x8d\xf9 7\x92\
+\x00\x00\x01j\x00\x00\x00\x00\x00\x01\x00\x00P#\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x00^\x00\x00\x00\x00\x00\x01\x00\x00+\xa1\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x00\xe0\x00\x00\x00\x00\x00\x01\x00\x00<#\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x01(\x00\x00\x00\x00\x00\x01\x00\x00L\xb7\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x01\xc0\x00\x00\x00\x00\x00\x01\x00\x00T\xa8\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x01\x8e\x00\x00\x00\x00\x00\x01\x00\x00R\x1b\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x01J\x00\x00\x00\x00\x00\x01\x00\x00M\xd2\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x01\xac\x00\x00\x00\x00\x00\x01\x00\x00S\xb3\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x00\x9c\x00\x00\x00\x00\x00\x01\x00\x005\x0b\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x00\xc2\x00\x00\x00\x00\x00\x01\x00\x006i\
+\x00\x00\x01\x8d\xf5\xaf\x80 \
+\x00\x00\x00\x86\x00\x00\x00\x00\x00\x01\x00\x003\x5c\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+\x00\x00\x01\x08\x00\x00\x00\x00\x00\x01\x00\x00C\xe8\
+\x00\x00\x01\x8d\xf5\xaf\x80\x1f\
+"
+
+def qInitResources():
+    QtCore.qRegisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+def qCleanupResources():
+    QtCore.qUnregisterResourceData(0x03, qt_resource_struct, qt_resource_name, qt_resource_data)
+
+qInitResources()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,13 +66,15 @@ testpaths = ["mne_qt_browser"]
 junit_family = "xunit2"
 
 [tool.ruff]
+exclude = ["__init__.py", "rc_icons.py"]
+
+[tool.ruff.lint]
 select = ["E", "F", "W", "D", "I"]
-exclude = ["__init__.py"]
 ignore = [
     "D100", # Missing docstring in public module
     "D104", # Missing docstring in public package
     "D413", # Missing blank line after last section
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
Following the discussion in https://github.com/cbrnr/mnelab/issues/401, I've implemented the same changes that work in MNELAB (i.e., integrating icons in Qt's Resource System). However, for some reason, this doesn't work here (icons are not shown, except for the Help icon, which is a generic system-wide icon).

To test this, you can try the following MWE:

```python
from pathlib import Path

import mne

sample_dir = mne.datasets.sample.data_path()
raw_path = Path(sample_dir) / 'MEG' / 'sample' / 'sample_audvis_raw.fif'
raw = mne.io.read_raw(raw_path)

mne.viz.set_browser_backend('qt')
raw.plot(block=True)
```

(TL;DR of the underlying issue: if two Qt apps run at the same time, i.e. one spawns the other, icons disappear if the apps manipulate the theme search path, which is what MNE-Qt-Browser currently does.)